### PR TITLE
Update domains

### DIFF
--- a/blacklists/cryptojacking/domains
+++ b/blacklists/cryptojacking/domains
@@ -2192,7 +2192,6 @@
 0.0.0.0iisl7wpf.me
 0.0.0.0ikpool.com
 0.0.0.0img.namunil.com
-0.0.0.0imhard4.men
 0.0.0.0imhvlhaelvvbrq.ru
 0.0.0.0imperium.getmyip.com
 0.0.0.0in-games.xyz


### PR DESCRIPTION
remove imhard4.men
at one point in history I ran a shitcoin mining pool on a subdomain, but it wasn't a crypto jacking site.  I found it on your list when I added your blacklist to my pihole