### PR TITLE
Split large files on whole lines, and update documentation accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repository mirrors the blacklists of the [UT1](http://www.ut-capitole.fr) w
 
 __Note__: this repository is only intended to mirror lists, to modify/update them please [contact](#see-also) the maintainer(s)
 
-__Important__: due to [a GitHub restriction](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github#file-size-limits) on file sizes, files that are bigger than 100MB are gzip-compressed
+__Important__: due to [a GitHub restriction](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github#file-size-limits) on file sizes, files that are bigger than 50 MB are split (on whole lines)
 
 ## Lists
 | Name | Size | Description |

--- a/scripts/split-large-files
+++ b/scripts/split-large-files
@@ -3,4 +3,4 @@
 set -euxo pipefail
 
 # split files that are larger than 50MB (GitHub limit is 100MB per file)
-find blacklists -type f -size +50M -exec bash -c 'split -b 50M -d -a 1 "{}" "{}." && rm "{}"' \;
+find blacklists -type f -size +50M -exec bash -c 'split -C 50M -d -a 1 "{}" "{}." && rm "{}"' \;


### PR DESCRIPTION
split based on max output file size comprised of whole lines
- `split -b` splits without checking if lines are split in the middle; this can cause issues if we use the splitted files as-is as a input for further processing without concatenating them first. 
- `split -C` is safer because it won't split in the middle of a line, so the splitted files will be made of whole lines only